### PR TITLE
chore(release): bump version to 0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lcod-kernel-js",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lcod-kernel-js",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "csv-parse": "^5.6.0",
         "tar": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lcod-kernel-js",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "demo": "node src/example.js",


### PR DESCRIPTION
Automated bump to 0.1.17 triggered from https://github.com/lcod-team/lcod-release/actions/runs/18917026626 via lcod-release.